### PR TITLE
Add homepage and repo links for published crates

### DIFF
--- a/pulse-binding-mainloop-glib/Cargo.toml
+++ b/pulse-binding-mainloop-glib/Cargo.toml
@@ -8,6 +8,8 @@ description = """
 A Rust language binding for the PulseAudio libpulse-mainloop-glib library.
 """
 keywords = ["binding", "pulse", "pulseaudio", "pulse-mainloop-glib", "audio"]
+homepage = "https://github.com/jnqnfe/pulse-binding-rust"
+repository = "https://github.com/jnqnfe/pulse-binding-rust"
 
 [dependencies]
 libpulse-binding = { path = "../pulse-binding", version = "2.2" }

--- a/pulse-binding-simple/Cargo.toml
+++ b/pulse-binding-simple/Cargo.toml
@@ -8,6 +8,8 @@ description = """
 A Rust language binding for the PulseAudio libpulse-simple library.
 """
 keywords = ["binding", "pulse", "pulseaudio", "pulse-simple", "audio"]
+homepage = "https://github.com/jnqnfe/pulse-binding-rust"
+repository = "https://github.com/jnqnfe/pulse-binding-rust"
 
 [dependencies]
 libpulse-binding = { path = "../pulse-binding", version = "2.2" }

--- a/pulse-binding/Cargo.toml
+++ b/pulse-binding/Cargo.toml
@@ -8,6 +8,8 @@ description = """
 A Rust language binding for the PulseAudio libpulse library.
 """
 keywords = ["binding", "pulse", "pulseaudio", "audio"]
+homepage = "https://github.com/jnqnfe/pulse-binding-rust"
+repository = "https://github.com/jnqnfe/pulse-binding-rust"
 
 [dependencies]
 libc = "0.2"

--- a/pulse-sys-mainloop-glib/Cargo.toml
+++ b/pulse-sys-mainloop-glib/Cargo.toml
@@ -9,6 +9,8 @@ A Rust language linking library for the PulseAudio libpulse-mainloop-glib librar
 keywords = ["binding", "pulse", "pulseaudio", "pulse-mainloop-glib", "audio"]
 links = "pulse-mainloop-glib"
 build = "build.rs"
+homepage = "https://github.com/jnqnfe/pulse-binding-rust"
+repository = "https://github.com/jnqnfe/pulse-binding-rust"
 
 [dependencies]
 libpulse-sys = { path = "../pulse-sys", version = "1.3" }

--- a/pulse-sys-simple/Cargo.toml
+++ b/pulse-sys-simple/Cargo.toml
@@ -9,6 +9,8 @@ A Rust language linking library for the PulseAudio libpulse-simple library.
 keywords = ["sys", "pulse", "pulseaudio", "pulse-simple", "audio"]
 links = "pulse-simple"
 build = "build.rs"
+homepage = "https://github.com/jnqnfe/pulse-binding-rust"
+repository = "https://github.com/jnqnfe/pulse-binding-rust"
 
 [dependencies]
 libpulse-sys = { path = "../pulse-sys", version = "1.3" }

--- a/pulse-sys/Cargo.toml
+++ b/pulse-sys/Cargo.toml
@@ -9,6 +9,8 @@ A Rust language linking library for the PulseAudio libpulse library.
 keywords = ["sys", "binding", "pulse", "pulseaudio", "audio"]
 links = "pulse"
 build = "build.rs"
+homepage = "https://github.com/jnqnfe/pulse-binding-rust"
+repository = "https://github.com/jnqnfe/pulse-binding-rust"
 
 [dependencies]
 libc = "0.2"


### PR DESCRIPTION
There were no links from crates.io to the repo