### PR TITLE
Disable `pa_encoding_from_string` by default.

### DIFF
--- a/pulse-binding-mainloop-glib/Cargo.toml
+++ b/pulse-binding-mainloop-glib/Cargo.toml
@@ -16,9 +16,11 @@ libpulse-binding = { path = "../pulse-binding", version = "2.2" }
 libpulse-mainloop-glib-sys = { path = "../pulse-sys-mainloop-glib", version = "1.3" }
 
 [features]
-default = ["pa_encoding_from_string"]
 #include format::Encoding::from_string method, for which the underlying C API symbol was missing before PA v12
-pa_encoding_from_string = ["libpulse-binding/pa_encoding_from_string"]
+pa_encoding_from_string = [
+	"libpulse-binding/pa_encoding_from_string",
+	"libpulse-mainloop-glib-sys/pa_encoding_from_string"
+]
 
 [badges]
 travis-ci = { repository = "jnqnfe/pulse-binding-rust" }

--- a/pulse-binding-simple/Cargo.toml
+++ b/pulse-binding-simple/Cargo.toml
@@ -17,9 +17,12 @@ libpulse-sys = { path = "../pulse-sys", version = "1.3" }
 libpulse-simple-sys = { path = "../pulse-sys-simple", version = "1.3" }
 
 [features]
-default = ["pa_encoding_from_string"]
 #include format::Encoding::from_string method, for which the underlying C API symbol was missing before PA v12
-pa_encoding_from_string = ["libpulse-binding/pa_encoding_from_string", "libpulse-sys/pa_encoding_from_string"]
+pa_encoding_from_string = [
+	"libpulse-binding/pa_encoding_from_string",
+	"libpulse-sys/pa_encoding_from_string",
+	"libpulse-simple-sys/pa_encoding_from_string"
+]
 
 [badges]
 travis-ci = { repository = "jnqnfe/pulse-binding-rust" }

--- a/pulse-binding/Cargo.toml
+++ b/pulse-binding/Cargo.toml
@@ -16,7 +16,6 @@ libc = "0.2"
 libpulse-sys = { path = "../pulse-sys", version = "1.3" }
 
 [features]
-default = ["pa_encoding_from_string"]
 #include format::Encoding::from_string method, for which the underlying C API symbol was missing before PA v12
 pa_encoding_from_string = ["libpulse-sys/pa_encoding_from_string"]
 

--- a/pulse-sys-mainloop-glib/Cargo.toml
+++ b/pulse-sys-mainloop-glib/Cargo.toml
@@ -16,7 +16,6 @@ repository = "https://github.com/jnqnfe/pulse-binding-rust"
 libpulse-sys = { path = "../pulse-sys", version = "1.3" }
 
 [features]
-default = ["pa_encoding_from_string"]
 #include format::Encoding::from_string method, for which the underlying C API symbol was missing before PA v12
 pa_encoding_from_string = ["libpulse-sys/pa_encoding_from_string"]
 

--- a/pulse-sys-simple/Cargo.toml
+++ b/pulse-sys-simple/Cargo.toml
@@ -16,7 +16,6 @@ repository = "https://github.com/jnqnfe/pulse-binding-rust"
 libpulse-sys = { path = "../pulse-sys", version = "1.3" }
 
 [features]
-default = ["pa_encoding_from_string"]
 #include format::Encoding::from_string method, for which the underlying C API symbol was missing before PA v12
 pa_encoding_from_string = ["libpulse-sys/pa_encoding_from_string"]
 

--- a/pulse-sys/Cargo.toml
+++ b/pulse-sys/Cargo.toml
@@ -16,7 +16,6 @@ repository = "https://github.com/jnqnfe/pulse-binding-rust"
 libc = "0.2"
 
 [features]
-default = ["pa_encoding_from_string"]
 #include pa_encoding_from_string function, symbol for which might be missing before PA v12
 pa_encoding_from_string = []
 


### PR DESCRIPTION
As it stands it appears impossible to disable this flag from a top-level application, and so it would seem easier for people to opt-in if they need the API (and aren't using Ubuntu 18.04, where the API isn't available).
I've also tried to ensure flag cascades down as required when enabled.