### PR TITLE
Print warnings with cargo:warning

### DIFF
--- a/pulse-sys-mainloop-glib/build.rs
+++ b/pulse-sys-mainloop-glib/build.rs
@@ -23,17 +23,16 @@ fn main() {
     config.cargo_metadata(false);
     let fallback = match config.probe(lib_name) {
         // We assume all failure here (being a non-version specific check) indicates no *.pc file
-        Err(pkg_config::Error::Failure{ .. }) => {
-            eprintln!("Pkg-config seems to not know about PulseAudio (dev package not installed?), \
+        Err(pkg_config::Error::Failure { .. }) => {
+            println!("cargo:warning=Pkg-config seems to not know about PulseAudio (dev package not installed?), \
                        trying generic fallback...");
             true
-        },
+        }
         // Also allow fallback if pkg-config not installed, or disabled
-        Err(pkg_config::Error::EnvNoPkgConfig(_)) |
-        Err(pkg_config::Error::Command { .. }) => {
-            eprintln!("No pkg-config or disabled, trying generic fallback...");
+        Err(pkg_config::Error::EnvNoPkgConfig(_)) | Err(pkg_config::Error::Command { .. }) => {
+            println!("cargo:warning=No pkg-config or disabled, trying generic fallback...");
             true
-        },
+        }
         // In all other cases we will perform a version-specfic check and honor the result
         _ => false,
     };
@@ -46,15 +45,14 @@ fn main() {
         return;
     }
 
-    config.cargo_metadata(true)
-          .atleast_version(min_version);
+    config.cargo_metadata(true).atleast_version(min_version);
 
     // Do version specific pkg-config check and honor result
     match config.probe(lib_name) {
         Err(e) => {
-            eprintln!("{}", e);
+            println!("cargo:warning={}", e);
             std::process::exit(1);
-        },
-        Ok(_) => {},
+        }
+        Ok(_) => {}
     }
 }

--- a/pulse-sys-simple/build.rs
+++ b/pulse-sys-simple/build.rs
@@ -23,17 +23,16 @@ fn main() {
     config.cargo_metadata(false);
     let fallback = match config.probe(lib_name) {
         // We assume all failure here (being a non-version specific check) indicates no *.pc file
-        Err(pkg_config::Error::Failure{ .. }) => {
-            eprintln!("Pkg-config seems to not know about PulseAudio (dev package not installed?), \
+        Err(pkg_config::Error::Failure { .. }) => {
+            println!("cargo:warning=Pkg-config seems to not know about PulseAudio (dev package not installed?), \
                        trying generic fallback...");
             true
-        },
+        }
         // Also allow fallback if pkg-config not installed, or disabled
-        Err(pkg_config::Error::EnvNoPkgConfig(_)) |
-        Err(pkg_config::Error::Command { .. }) => {
-            eprintln!("No pkg-config or disabled, trying generic fallback...");
+        Err(pkg_config::Error::EnvNoPkgConfig(_)) | Err(pkg_config::Error::Command { .. }) => {
+            println!("cargo:warning=No pkg-config or disabled, trying generic fallback...");
             true
-        },
+        }
         // In all other cases we will perform a version-specfic check and honor the result
         _ => false,
     };
@@ -46,15 +45,14 @@ fn main() {
         return;
     }
 
-    config.cargo_metadata(true)
-          .atleast_version(min_version);
+    config.cargo_metadata(true).atleast_version(min_version);
 
     // Do version specific pkg-config check and honor result
     match config.probe(lib_name) {
         Err(e) => {
-            eprintln!("{}", e);
+            println!("cargo:warning={}", e);
             std::process::exit(1);
-        },
-        Ok(_) => {},
+        }
+        Ok(_) => {}
     }
 }

--- a/pulse-sys/build.rs
+++ b/pulse-sys/build.rs
@@ -36,17 +36,16 @@ fn main() {
     config.cargo_metadata(false);
     let fallback = match config.probe(lib_name) {
         // We assume all failure here (being a non-version specific check) indicates no *.pc file
-        Err(pkg_config::Error::Failure{ .. }) => {
-            eprintln!("Pkg-config seems to not know about PulseAudio (dev package not installed?), \
+        Err(pkg_config::Error::Failure { .. }) => {
+            println!("cargo:warning=Pkg-config seems to not know about PulseAudio (dev package not installed?), \
                        trying generic fallback...");
             true
-        },
+        }
         // Also allow fallback if pkg-config not installed, or disabled
-        Err(pkg_config::Error::EnvNoPkgConfig(_)) |
-        Err(pkg_config::Error::Command { .. }) => {
-            eprintln!("No pkg-config or disabled, trying generic fallback...");
+        Err(pkg_config::Error::EnvNoPkgConfig(_)) | Err(pkg_config::Error::Command { .. }) => {
+            println!("cargo:warning=No pkg-config or disabled, trying generic fallback...");
             true
-        },
+        }
         // In all other cases we will perform a version-specfic check and honor the result
         _ => false,
     };
@@ -59,15 +58,14 @@ fn main() {
         return;
     }
 
-    config.cargo_metadata(true)
-          .atleast_version(min_version);
+    config.cargo_metadata(true).atleast_version(min_version);
 
     // Do version specific pkg-config check and honor result
     match config.probe(lib_name) {
         Err(e) => {
-            eprintln!("{}", e);
+            println!("cargo:warning={}", e);
             std::process::exit(1);
-        },
-        Ok(_) => {},
+        }
+        Ok(_) => {}
     }
 }


### PR DESCRIPTION
`eprintln!` does not appear in Cargo output; however, we can give Cargo
the warning instruction [1], which will display a warning with the specified
message.

[1] https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargowarningmessage

---

See this conversation from IRC on why this change is a good idea: https://logs.nix.samueldr.com/nixos/2020-06-01#1590971042-1590972296.