### PR TITLE
Fix pa_glib_mainloop_free segfault

### DIFF
--- a/pulse-binding-mainloop-glib/src/lib.rs
+++ b/pulse-binding-mainloop-glib/src/lib.rs
@@ -103,7 +103,7 @@ impl MainloopSignals for Mainloop {}
 
 /// Drop function for MainloopInner<MainloopInternal>.
 fn drop_actual(self_: &mut MainloopInner<MainloopInternal>) {
-    unsafe { capi::pa_glib_mainloop_free(mem::transmute(&self_.ptr)) };
+    unsafe { capi::pa_glib_mainloop_free(mem::transmute(self_.ptr)) };
     self_.ptr = null_mut::<MainloopInternal>();
     self_.api = null::<MainloopApi>();
 }


### PR DESCRIPTION
It seems the `pa_glib_mainloop_free` was slightly off with what it should free and that resulted in a segfault.

```
// Mainloop::new
unsafe { mem::transmute(ptr) } = 0x0000556193e6fbc0
// Mainloop::drop_actual
unsafe { mem::transmute(&self_.ptr) } = 0x0000556193e6fcf0
unsafe { mem::transmute(self_.ptr) } = 0x0000556193e6fbc0
```

BT
```
Program received signal SIGSEGV, Segmentation fault.                                                                                                                                                                                           
0x00007ffff7e0862b in ?? () from /usr/lib/libpulse-mainloop-glib.so.0                                                                                                                                                                          
(gdb) bt                                                                                                                                                                                                                                       
#0  0x00007ffff7e0862b in  () at /usr/lib/libpulse-mainloop-glib.so.0                                                                                                                                                                          
#1  0x00007ffff7e09863 in pa_glib_mainloop_free () at /usr/lib/libpulse-mainloop-glib.so.0                                                                                                                                                     
#2  0x0000555555560c8b in libpulse_glib_binding::drop_actual (self_=0x5555555cacf0) at /home/dante/projects/pulse-binding-rust/pulse-binding-mainloop-glib/src/lib.rs:106                                                                      
#3  0x0000555555560f56 in libpulse_binding::mainloop::api::{{impl}}::drop<libpulse_glib_binding::MainloopInternal> (self=0x5555555cacf0) at /home/dante/projects/pulse-binding-rust/pulse-binding/src/mainloop/api.rs:80                       
#4  0x0000555555560f2f in core::ptr::drop_in_place<libpulse_binding::mainloop::api::MainloopInner<libpulse_glib_binding::MainloopInternal>> ()                                                                                                 
    at /home/dante/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:175                                                                                                                     
#5  0x000055555555cf60 in alloc::rc::{{impl}}::drop<libpulse_binding::mainloop::api::MainloopInner<libpulse_glib_binding::MainloopInternal>> (self=0x5555555c3978)                                                                             
    at /home/dante/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/rc.rs:1207                                                                                                                        
#6  0x000055555555c93e in core::ptr::drop_in_place<alloc::rc::Rc<libpulse_binding::mainloop::api::MainloopInner<libpulse_glib_binding::MainloopInternal>>> ()                                                                                  
    at /home/dante/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:175                                                                                                                     
#7  0x000055555555cafe in core::ptr::drop_in_place<libpulse_glib_binding::Mainloop> () at /home/dante/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:175                                  
#8  0x000055555555cbce in core::ptr::drop_in_place<core::cell::UnsafeCell<libpulse_glib_binding::Mainloop>> () at /home/dante/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:175          
#9  0x000055555555cb55 in core::ptr::drop_in_place<core::cell::RefCell<libpulse_glib_binding::Mainloop>> () at /home/dante/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:175             
#10 0x000055555555d09c in alloc::rc::{{impl}}::drop<core::cell::RefCell<libpulse_glib_binding::Mainloop>> (self=0x5555555ca5d0)                                                                                                                
    at /home/dante/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/alloc/src/rc.rs:1207                                                                                                                        
#11 0x000055555555c95e in core::ptr::drop_in_place<alloc::rc::Rc<core::cell::RefCell<libpulse_glib_binding::Mainloop>>> ()                                                                                                                     
    at /home/dante/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/mod.rs:175                                                                                                                     
#12 0x000055555555ff9d in pulse_repro::pulseaudio::{{closure}} () at src/main.rs:46                                                                                                                                                            
#13 0x0000555555560a87 in core::future::from_generator::{{impl}}::poll<generator-0> (self=..., cx=0x7fffffffd8d8) at /home/dante/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/mod.rs:80     
#14 0x0000555555565a4c in futures_task::future_obj::{{impl}}::poll<()> (self=..., cx=0x7fffffffd8d8) at /home/dante/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-task-0.3.8/src/future_obj.rs:86                                    
#15 0x000055555556434c in futures_util::future::future::FutureExt::poll_unpin<futures_task::future_obj::LocalFutureObj<()>> (self=0x5555555caaa0, cx=0x7fffffffd8d8)                                                                           
    at /home/dante/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/future/future/mod.rs:561                                                                                                                             
#16 0x0000555555563432 in glib::main_context_futures::{{impl}}::poll (self=..., ctx=0x7fffffffd8d8) at /home/dante/.cargo/registry/src/github.com-1ecc6299db9ec823/glib-0.10.3/src/main_context_futures.rs:35                                  
#17 0x000055555556324c in futures_util::future::future::FutureExt::poll_unpin<glib::main_context_futures::FutureWrapper> (self=0x5555555caa90, cx=0x7fffffffd8d8)                                                                              
    at /home/dante/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.8/src/future/future/mod.rs:561                                                                                                                             
#18 0x0000555555563a3f in glib::main_context_futures::{{impl}}::poll::{{closure}} () at /home/dante/.cargo/registry/src/github.com-1ecc6299db9ec823/glib-0.10.3/src/main_context_futures.rs:211                                                
#19 0x0000555555561eb2 in glib::auto::main_context::MainContext::with_thread_default<core::task::poll::Poll<()>,closure-0> (self=0x7fffffffd990, func=...)                                                                                     
    at /home/dante/.cargo/registry/src/github.com-1ecc6299db9ec823/glib-0.10.3/src/main_context.rs:124
#20 0x0000555555563984 in glib::main_context_futures::TaskSource::poll (self=0x5555555caa30) at /home/dante/.cargo/registry/src/github.com-1ecc6299db9ec823/glib-0.10.3/src/main_context_futures.rs:205
#21 0x0000555555563493 in glib::main_context_futures::TaskSource::dispatch (source=0x5555555caa30, callback=..., _user_data=0x0) at /home/dante/.cargo/registry/src/github.com-1ecc6299db9ec823/glib-0.10.3/src/main_context_futures.rs:72
#22 0x00007ffff7e5f914 in g_main_context_dispatch () at /usr/lib/libglib-2.0.so.0
#23 0x00007ffff7eb37d1 in  () at /usr/lib/libglib-2.0.so.0
#24 0x00007ffff7e5ee63 in g_main_loop_run () at /usr/lib/libglib-2.0.so.0
#25 0x0000555555563171 in glib::auto::main_loop::MainLoop::run (self=0x7fffffffdb88) at /home/dante/.cargo/registry/src/github.com-1ecc6299db9ec823/glib-0.10.3/src/auto/main_loop.rs:46
#26 0x000055555555dc61 in pulse_repro::main () at src/main.rs:54
```

```
rustc --version
rustc 1.48.0 (7eac88abb 2020-11-16)
```