### PR TITLE
Derive Clone for SinkInfo and SinkPortInfo

### DIFF
--- a/pulse-binding/src/context/introspect.rs
+++ b/pulse-binding/src/context/introspect.rs
@@ -261,7 +261,7 @@ impl Drop for Introspector {
 ///
 /// Please note that this structure can be extended as part of evolutionary API updates at any time
 /// in any new release.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SinkPortInfo<'a> {
     /// Name of this port.
     pub name: Option<Cow<'a, str>>,
@@ -333,7 +333,7 @@ impl<'a> SinkPortInfo<'a> {
 ///
 /// Please note that this structure can be extended as part of evolutionary API updates at any time
 /// in any new release.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SinkInfo<'a> {
     /// Name of the sink.
     pub name: Option<Cow<'a, str>>,


### PR DESCRIPTION
The `Clone` implementation enables using data from a `SinkInfo` outside the callback functions where a reference to one is made available