### PR TITLE
Update bitflags to v1.3

### DIFF
--- a/pulse-binding/Cargo.toml
+++ b/pulse-binding/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["README.md"]
 
 [dependencies]
 libc = "0.2"
-bitflags = "1.2"
+bitflags = "1.3"
 num-traits = "0.2"
 num-derive = "0.3"
 libpulse-sys = { path = "../pulse-sys", version = "1.19", default-features = false }


### PR DESCRIPTION
bitflags 1.3 provides a few convenient features, e.g. `from_bits` as a const fn.

See the changelog for details: https://github.com/bitflags/bitflags/blob/a13bb56b92cc3c45ac67eb5d3e6637124f43cb2f/CHANGELOG.md

PS: For some reason, the bitflags version bump to v1.3 is already mentioned in the changelog for pulse-binding 2.25.0, but that version doesn't actually bump the bitflags version.