### PR TITLE
use ProbeError from pkg-config

### DIFF
--- a/pulse-sys-simple/Cargo.toml
+++ b/pulse-sys-simple/Cargo.toml
@@ -17,7 +17,7 @@ build = "build.rs"
 libpulse-sys = { path = "../pulse-sys", version = "1.19", default-features = false }
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "0.3.23"
 
 [features]
 default = ["pa_v8"]

--- a/pulse-sys-simple/build.rs
+++ b/pulse-sys-simple/build.rs
@@ -26,7 +26,7 @@ fn main() {
     config.cargo_metadata(false);
     let fallback = match config.probe(lib_name) {
         // We assume all failure here (being a non-version specific check) indicates no *.pc file
-        Err(pkg_config::Error::Failure { .. }) => {
+        Err(pkg_config::Error::ProbeFailure { .. }) => {
             println!("cargo:warning=Pkg-config seems to not know about PulseAudio (dev package not installed?), \
                        trying generic fallback...");
             true

--- a/pulse-sys/Cargo.toml
+++ b/pulse-sys/Cargo.toml
@@ -22,7 +22,7 @@ num-derive = "0.3"
 winapi = { version = "0.3", features = ["winsock2"], default-features = false }
 
 [build-dependencies]
-pkg-config = "0.3"
+pkg-config = "0.3.23"
 
 [features]
 default = ["pa_v8"]

--- a/pulse-sys/build.rs
+++ b/pulse-sys/build.rs
@@ -43,7 +43,7 @@ fn main() {
     config.cargo_metadata(false);
     let fallback = match config.probe(lib_name) {
         // We assume all failure here (being a non-version specific check) indicates no *.pc file
-        Err(pkg_config::Error::Failure { .. }) => {
+        Err(pkg_config::Error::ProbeFailure { .. }) => {
             println!("cargo:warning=Pkg-config seems to not know about PulseAudio (dev package not installed?), \
                        trying generic fallback...");
             true


### PR DESCRIPTION
pkgconfig 0.3.23 changed added a new error in the case of a probe
failure (see https://github.com/rust-lang/pkg-config-rs/pull/127)

This can cause previously building configuration (ie confs without the
dev package installed for pulseaudio) to fail.

This change uses the new error from pkgconfig instead of the old one.