### PR TITLE
Make "single-use" callbacks `FnOnce`

### DIFF
--- a/pulse-binding/src/context/ext_device_manager.rs
+++ b/pulse-binding/src/context/ext_device_manager.rs
@@ -170,20 +170,20 @@ impl DeviceManager {
     ///
     /// Panics if the underlying C function returns a null pointer.
     pub fn set_device_description<F>(&mut self, device: &str, description: &str, callback: F)
-        -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+        -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
         // Warning: New CStrings will be immediately freed if not bound to a
         // variable, leading to as_ptr() giving dangling pointers!
         let c_dev = CString::new(device.clone()).unwrap();
         let c_desc = CString::new(description.clone()).unwrap();
 
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe {
             capi::pa_ext_device_manager_set_device_description(self.context, c_dev.as_ptr(),
                 c_desc.as_ptr(), Some(super::success_cb_proxy), cb_data)
         };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Deletes entries from the device database.
@@ -191,8 +191,8 @@ impl DeviceManager {
     /// The callback must accept a `bool`, which indicates success.
     ///
     /// Panics if the underlying C function returns a null pointer.
-    pub fn delete<F>(&mut self, devices: &[&str], callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+    pub fn delete<F>(&mut self, devices: &[&str], callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -209,10 +209,10 @@ impl DeviceManager {
         }
         c_dev_ptrs.push(null());
 
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_ext_device_manager_delete(self.context, c_dev_ptrs.as_ptr(),
             Some(super::success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Enables the role-based device-priority routing mode.
@@ -221,15 +221,15 @@ impl DeviceManager {
     ///
     /// Panics if the underlying C function returns a null pointer.
     pub fn enable_role_device_priority_routing<F>(&mut self, enable: bool, callback: F)
-        -> Operation<dyn FnMut(bool)>
+        -> Operation<dyn FnOnce(bool)>
         where F: FnMut(bool) + 'static
     {
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe {
             capi::pa_ext_device_manager_enable_role_device_priority_routing(self.context,
                 enable as i32, Some(super::success_cb_proxy), cb_data)
         };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Reorders the position of a given device in the priority list to give preference to it.
@@ -238,8 +238,8 @@ impl DeviceManager {
     ///
     /// Panics if the underlying C function returns a null pointer.
     pub fn reorder_devices_for_role<F>(&mut self, role: &str, devices: &[&str], callback: F)
-        -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+        -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -257,12 +257,12 @@ impl DeviceManager {
         }
         c_dev_ptrs.push(null());
 
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe {
             capi::pa_ext_device_manager_reorder_devices_for_role(self.context, c_role.as_ptr(),
                 c_dev_ptrs.as_ptr(), Some(super::success_cb_proxy), cb_data)
         };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Subscribes to changes in the device database.
@@ -270,13 +270,13 @@ impl DeviceManager {
     /// The callback must accept a `bool`, which indicates success.
     ///
     /// Panics if the underlying C function returns a null pointer.
-    pub fn subscribe<F>(&mut self, enable: bool, callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+    pub fn subscribe<F>(&mut self, enable: bool, callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_ext_device_manager_subscribe(self.context, enable as i32,
             Some(super::success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the subscription callback that is called when [`subscribe()`](Self::subscribe) was

--- a/pulse-binding/src/context/ext_device_restore.rs
+++ b/pulse-binding/src/context/ext_device_restore.rs
@@ -112,13 +112,13 @@ impl DeviceRestore {
     /// The callback must accept a `bool`, which indicates success.
     ///
     /// Panics if the underlying C function returns a null pointer.
-    pub fn subscribe<F>(&mut self, enable: bool, callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+    pub fn subscribe<F>(&mut self, enable: bool, callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_ext_device_restore_subscribe(self.context, enable as i32,
             Some(super::success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the subscription callback that is called when [`subscribe()`](Self::subscribe) was
@@ -168,8 +168,8 @@ impl DeviceRestore {
     ///
     /// Panics if the underlying C function returns a null pointer.
     pub fn save_formats<F>(&mut self, type_: def::Device, index: u32,
-        formats: &mut [&mut format::Info], callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+        formats: &mut [&mut format::Info], callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
         // Capture array of pointers to the above `format::InfoInternal` objects
         let mut format_ptrs: Vec<*mut capi::pa_format_info> = Vec::with_capacity(formats.len());
@@ -177,13 +177,13 @@ impl DeviceRestore {
             format_ptrs.push(unsafe { mem::transmute(&format.ptr) });
         }
 
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe {
             capi::pa_ext_device_restore_save_formats(self.context, type_, index,
                 format_ptrs.len() as u8, format_ptrs.as_ptr(), Some(super::success_cb_proxy),
                 cb_data)
         };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 }
 

--- a/pulse-binding/src/context/ext_stream_restore.rs
+++ b/pulse-binding/src/context/ext_stream_restore.rs
@@ -132,16 +132,16 @@ impl StreamRestore {
     ///
     /// Panics if the underlying C function returns a null pointer.
     pub fn write<F>(&mut self, mode: proplist::UpdateMode, data: &[&Info],
-        apply_immediately: bool, callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+        apply_immediately: bool, callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe {
             capi::pa_ext_stream_restore_write(self.context, mode, mem::transmute(data.as_ptr()),
                 data.len() as u32, apply_immediately as i32, Some(super::success_cb_proxy),
                 cb_data)
         };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Deletes entries from the stream database.
@@ -149,8 +149,8 @@ impl StreamRestore {
     /// The callback must accept a `bool`, which indicates success.
     ///
     /// Panics if the underlying C function returns a null pointer.
-    pub fn delete<F>(&mut self, streams: &[&str], callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+    pub fn delete<F>(&mut self, streams: &[&str], callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -167,10 +167,10 @@ impl StreamRestore {
         }
         c_stream_ptrs.push(null());
 
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_ext_stream_restore_delete(self.context, c_stream_ptrs.as_ptr(),
             Some(super::success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Subscribes to changes in the stream database.
@@ -178,13 +178,13 @@ impl StreamRestore {
     /// The callback must accept a `bool`, which indicates success.
     ///
     /// Panics if the underlying C function returns a null pointer.
-    pub fn subscribe<F>(&mut self, enable: bool, callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+    pub fn subscribe<F>(&mut self, enable: bool, callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_ext_stream_restore_subscribe(self.context, enable as i32,
             Some(super::success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the subscription callback that is called when [`subscribe()`](Self::subscribe) was

--- a/pulse-binding/src/context/introspect.rs
+++ b/pulse-binding/src/context/introspect.rs
@@ -506,13 +506,13 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_sink_volume_by_index(&mut self, index: u32, volume: &ChannelVolumes,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_sink_volume_by_index(self.context, index,
             volume.as_ref(), cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the volume of a sink device specified by its name.
@@ -521,7 +521,7 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_sink_volume_by_name(&mut self, name: &str, volume: &ChannelVolumes,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -531,7 +531,7 @@ impl Introspector {
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_sink_volume_by_name(self.context, c_name.as_ptr(),
             volume.as_ref(), cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the mute switch of a sink device specified by its index.
@@ -540,13 +540,13 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_sink_mute_by_index(&mut self, index: u32, mute: bool,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_sink_mute_by_index(self.context, index, mute as i32,
             cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the mute switch of a sink device specified by its name.
@@ -555,7 +555,7 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_sink_mute_by_name(&mut self, name: &str, mute: bool,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -565,7 +565,7 @@ impl Introspector {
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_sink_mute_by_name(self.context, c_name.as_ptr(),
             mute as i32, cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Suspends/Resumes a sink.
@@ -574,7 +574,7 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn suspend_sink_by_name(&mut self, sink_name: &str, suspend: bool,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -584,7 +584,7 @@ impl Introspector {
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_suspend_sink_by_name(self.context, c_name.as_ptr(),
             suspend as i32, cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Suspends/Resumes a sink.
@@ -594,13 +594,13 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn suspend_sink_by_index(&mut self, index: u32, suspend: bool,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_suspend_sink_by_index(self.context, index,
             suspend as i32, cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Changes the profile of a sink.
@@ -609,7 +609,7 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_sink_port_by_index(&mut self, index: u32, port: &str,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -619,7 +619,7 @@ impl Introspector {
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_sink_port_by_index(self.context, index,
             c_port.as_ptr(), cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Changes the profile of a sink.
@@ -628,7 +628,7 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_sink_port_by_name(&mut self, name: &str, port: &str,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -639,7 +639,7 @@ impl Introspector {
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_sink_port_by_name(self.context, c_name.as_ptr(),
             c_port.as_ptr(), cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 }
 
@@ -911,13 +911,13 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_source_volume_by_index(&mut self, index: u32, volume: &ChannelVolumes,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_source_volume_by_index(self.context, index,
             volume.as_ref(), cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the volume of a source device specified by its name.
@@ -926,7 +926,7 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_source_volume_by_name(&mut self, name: &str, volume: &ChannelVolumes,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -936,7 +936,7 @@ impl Introspector {
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_source_volume_by_name(self.context,
             c_name.as_ptr(), volume.as_ref(), cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the mute switch of a source device specified by its index.
@@ -945,13 +945,13 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_source_mute_by_index(&mut self, index: u32, mute: bool,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_source_mute_by_index(self.context, index,
             mute as i32, cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the mute switch of a source device specified by its name.
@@ -960,7 +960,7 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_source_mute_by_name(&mut self, name: &str, mute: bool,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -970,7 +970,7 @@ impl Introspector {
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_source_mute_by_name(self.context, c_name.as_ptr(),
             mute as i32, cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Suspends/Resumes a source.
@@ -979,7 +979,7 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn suspend_source_by_name(&mut self, name: &str, suspend: bool,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -989,7 +989,7 @@ impl Introspector {
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_suspend_source_by_name(self.context, c_name.as_ptr(),
             suspend as i32, cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Suspends/Resumes a source.
@@ -999,13 +999,13 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn suspend_source_by_index(&mut self, index: u32, suspend: bool,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_suspend_source_by_index(self.context, index,
             suspend as i32, cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Changes the profile of a source.
@@ -1014,7 +1014,7 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_source_port_by_index(&mut self, index: u32, port: &str,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -1024,7 +1024,7 @@ impl Introspector {
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_source_port_by_index(self.context, index,
             c_port.as_ptr(), cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Changes the profile of a source.
@@ -1033,7 +1033,7 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_source_port_by_name(&mut self, name: &str, port: &str,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -1044,7 +1044,7 @@ impl Introspector {
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_source_port_by_name(self.context, c_name.as_ptr(),
             c_port.as_ptr(), cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 }
 
@@ -1132,13 +1132,13 @@ impl Introspector {
     /// Gets some information about the server.
     ///
     /// Panics on error, i.e. invalid arguments or state.
-    pub fn get_server_info<F>(&self, callback: F) -> Operation<dyn FnMut(&ServerInfo)>
-        where F: FnMut(&ServerInfo) + 'static
+    pub fn get_server_info<F>(&self, callback: F) -> Operation<dyn FnOnce(&ServerInfo)>
+        where F: FnOnce(&ServerInfo) + 'static
     {
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(&ServerInfo)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(&ServerInfo)>(Box::new(callback));
         let ptr = unsafe { capi::pa_context_get_server_info(self.context,
             Some(get_server_info_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(&ServerInfo)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(&ServerInfo)>)
     }
 }
 
@@ -1153,7 +1153,7 @@ fn get_server_info_cb_proxy(_: *mut ContextInternal, i: *const ServerInfoInterna
         let obj = ServerInfo::new_from_raw(i);
 
         // Note, destroys closure callback after use - restoring outer box means it gets dropped
-        let mut callback = get_su_callback::<dyn FnMut(&ServerInfo)>(userdata);
+        let callback = get_su_callback::<dyn FnOnce(&ServerInfo)>(userdata);
         (callback)(&obj);
     });
 }
@@ -1237,18 +1237,18 @@ impl Introspector {
     /// Panics on error, i.e. invalid arguments or state. The callback is provided with the
     /// index.
     pub fn load_module<F>(&mut self, name: &str, argument: &str, callback: F)
-        -> Operation<dyn FnMut(u32)>
-        where F: FnMut(u32) + 'static
+        -> Operation<dyn FnOnce(u32)>
+        where F: FnOnce(u32) + 'static
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
         let c_name = CString::new(name.clone()).unwrap();
         let c_arg = CString::new(argument.clone()).unwrap();
 
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(u32)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(u32)>(Box::new(callback));
         let ptr = unsafe { capi::pa_context_load_module(self.context, c_name.as_ptr(),
             c_arg.as_ptr(), Some(context_index_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(u32)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(u32)>)
     }
 
     /// Unloads a module.
@@ -1256,13 +1256,13 @@ impl Introspector {
     /// Panics on error, i.e. invalid arguments or state.
     ///
     /// The callback must accept a `bool`, which indicates success.
-    pub fn unload_module<F>(&mut self, index: u32, callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+    pub fn unload_module<F>(&mut self, index: u32, callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_context_unload_module(self.context, index,
             Some(super::success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 }
 
@@ -1285,7 +1285,7 @@ extern "C"
 fn context_index_cb_proxy(_: *mut ContextInternal, index: u32, userdata: *mut c_void) {
     let _ = std::panic::catch_unwind(|| {
         // Note, destroys closure callback after use - restoring outer box means it gets dropped
-        let mut callback = get_su_callback::<dyn FnMut(u32)>(userdata);
+        let callback = get_su_callback::<dyn FnOnce(u32)>(userdata);
         (callback)(index);
     });
 }
@@ -1307,8 +1307,8 @@ impl Introspector {
     #[cfg(any(doc, feature = "pa_v15"))]
     #[cfg_attr(docsrs, doc(cfg(feature = "pa_v15")))]
     pub fn send_message_to_object<F>(&mut self, recipient_name: &str, message: &str,
-        message_parameters: &str, callback: F) -> Operation<dyn FnMut(bool, Option<String>)>
-        where F: FnMut(bool, Option<String>) + 'static
+        message_parameters: &str, callback: F) -> Operation<dyn FnOnce(bool, Option<String>)>
+        where F: FnOnce(bool, Option<String>) + 'static
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -1316,11 +1316,11 @@ impl Introspector {
         let c_message = CString::new(message.clone()).unwrap();
         let c_message_parameters = CString::new(message_parameters.clone()).unwrap();
 
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool, Option<String>)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool, Option<String>)>(Box::new(callback));
         let ptr = unsafe { capi::pa_context_send_message_to_object(self.context,
             c_recipient_name.as_ptr(), c_message.as_ptr(), c_message_parameters.as_ptr(),
             Some(send_message_to_object_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool, Option<String>)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool, Option<String>)>)
     }
 }
 
@@ -1345,7 +1345,7 @@ fn send_message_to_object_cb_proxy(_: *mut ContextInternal, success: i32, respon
             },
         };
         // Note, destroys closure callback after use - restoring outer box means it gets dropped
-        let mut callback = get_su_callback::<dyn FnMut(bool, Option<String>)>(userdata);
+        let callback = get_su_callback::<dyn FnOnce(bool, Option<String>)>(userdata);
         (callback)(success_actual, r);
     });
 }
@@ -1429,13 +1429,13 @@ impl Introspector {
     /// Panics on error, i.e. invalid arguments or state.
     ///
     /// The callback must accept a `bool`, which indicates success.
-    pub fn kill_client<F>(&mut self, index: u32, callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+    pub fn kill_client<F>(&mut self, index: u32, callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_context_kill_client(self.context, index,
             Some(super::success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 }
 
@@ -1813,7 +1813,7 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_card_profile_by_index(&mut self, index: u32, profile: &str,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -1823,7 +1823,7 @@ impl Introspector {
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_card_profile_by_index(self.context, index,
             c_profile.as_ptr(), cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Changes the profile of a card.
@@ -1832,7 +1832,7 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_card_profile_by_name(&mut self, name: &str, profile: &str,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -1843,7 +1843,7 @@ impl Introspector {
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_card_profile_by_name(self.context, c_name.as_ptr(),
             c_profile.as_ptr(), cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the latency offset of a port.
@@ -1852,7 +1852,7 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_port_latency_offset(&mut self, card_name: &str, port_name: &str, offset: i64,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -1863,7 +1863,7 @@ impl Introspector {
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_port_latency_offset(self.context, c_name.as_ptr(),
             c_port.as_ptr(), offset, cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 }
 
@@ -2023,7 +2023,7 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn move_sink_input_by_name(&mut self, index: u32, sink_name: &str,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -2033,7 +2033,7 @@ impl Introspector {
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_move_sink_input_by_name(self.context, index,
             c_name.as_ptr(), cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Moves the specified sink input to a different sink.
@@ -2042,13 +2042,13 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn move_sink_input_by_index(&mut self, index: u32, sink_index: u32,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_move_sink_input_by_index(self.context, index,
             sink_index, cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the volume of a sink input stream.
@@ -2057,13 +2057,13 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_sink_input_volume(&mut self, index: u32, volume: &ChannelVolumes,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_sink_input_volume(self.context, index,
             volume.as_ref(), cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the mute switch of a sink input stream.
@@ -2072,13 +2072,13 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_sink_input_mute(&mut self, index: u32, mute: bool,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_sink_input_mute(self.context, index, mute as i32,
             cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Kills a sink input.
@@ -2086,13 +2086,13 @@ impl Introspector {
     /// Panics on error, i.e. invalid arguments or state.
     ///
     /// The callback must accept a `bool`, which indicates success.
-    pub fn kill_sink_input<F>(&mut self, index: u32, callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+    pub fn kill_sink_input<F>(&mut self, index: u32, callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_context_kill_sink_input(self.context, index,
             Some(super::success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 }
 
@@ -2252,7 +2252,7 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn move_source_output_by_name(&mut self, index: u32, source_name: &str,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -2262,7 +2262,7 @@ impl Introspector {
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_move_source_output_by_name(self.context, index,
             c_name.as_ptr(), cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Moves the specified source output to a different source.
@@ -2271,13 +2271,13 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn move_source_output_by_index(&mut self, index: u32, source_index: u32,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_move_source_output_by_index(self.context, index,
             source_index, cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the volume of a source output stream.
@@ -2286,13 +2286,13 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_source_output_volume(&mut self, index: u32, volume: &ChannelVolumes,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_source_output_volume(self.context, index,
             volume.as_ref(), cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the mute switch of a source output stream.
@@ -2301,13 +2301,13 @@ impl Introspector {
     ///
     /// The optional callback must accept a `bool`, which indicates success.
     pub fn set_source_output_mute(&mut self, index: u32, mute: bool,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, super::success_cb_proxy);
         let ptr = unsafe { capi::pa_context_set_source_output_mute(self.context, index, mute as i32,
             cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Kills a source output.
@@ -2315,13 +2315,13 @@ impl Introspector {
     /// Panics on error, i.e. invalid arguments or state.
     ///
     /// The callback must accept a `bool`, which indicates success.
-    pub fn kill_source_output<F>(&mut self, index: u32, callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+    pub fn kill_source_output<F>(&mut self, index: u32, callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_context_kill_source_output(self.context, index,
             Some(super::success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 }
 
@@ -2345,13 +2345,13 @@ impl Introspector {
     /// Gets daemon memory block statistics.
     ///
     /// Panics on error, i.e. invalid arguments or state.
-    pub fn stat<F>(&self, callback: F) -> Operation<dyn FnMut(&StatInfo)>
-        where F: FnMut(&StatInfo) + 'static
+    pub fn stat<F>(&self, callback: F) -> Operation<dyn FnOnce(&StatInfo)>
+        where F: FnOnce(&StatInfo) + 'static
     {
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(&StatInfo)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(&StatInfo)>(Box::new(callback));
         let ptr =
             unsafe { capi::pa_context_stat(self.context, Some(get_stat_info_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(&StatInfo)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(&StatInfo)>)
     }
 }
 
@@ -2363,7 +2363,7 @@ fn get_stat_info_cb_proxy(_: *mut ContextInternal, i: *const StatInfo, userdata:
     let _ = std::panic::catch_unwind(|| {
         assert!(!i.is_null());
         // Note, destroys closure callback after use - restoring outer box means it gets dropped
-        let mut callback = get_su_callback::<dyn FnMut(&StatInfo)>(userdata);
+        let callback = get_su_callback::<dyn FnOnce(&StatInfo)>(userdata);
         (callback)(unsafe { &*i });
     });
 }

--- a/pulse-binding/src/context/mod.rs
+++ b/pulse-binding/src/context/mod.rs
@@ -381,13 +381,13 @@ impl Context {
     /// The callback must accept a `bool`, which indicates success.
     ///
     /// Panics if the underlying C function returns a null pointer.
-    pub fn exit_daemon<F>(&mut self, callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+    pub fn exit_daemon<F>(&mut self, callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr =
             unsafe { capi::pa_context_exit_daemon(self.ptr, Some(success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the name of the default sink.
@@ -395,17 +395,17 @@ impl Context {
     /// The callback must accept a `bool`, which indicates success.
     ///
     /// Panics if the underlying C function returns a null pointer.
-    pub fn set_default_sink<F>(&mut self, name: &str, callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+    pub fn set_default_sink<F>(&mut self, name: &str, callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
         let c_name = CString::new(name.clone()).unwrap();
 
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_context_set_default_sink(self.ptr, c_name.as_ptr(),
             Some(success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the name of the default source.
@@ -413,17 +413,17 @@ impl Context {
     /// The callback must accept a `bool`, which indicates success.
     ///
     /// Panics if the underlying C function returns a null pointer.
-    pub fn set_default_source<F>(&mut self, name: &str, callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+    pub fn set_default_source<F>(&mut self, name: &str, callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
         let c_name = CString::new(name.clone()).unwrap();
 
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_context_set_default_source(self.ptr, c_name.as_ptr(),
             Some(success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Checks if this is a connection to a local daemon.
@@ -441,17 +441,17 @@ impl Context {
     /// Sets a different application name for context on the server.
     ///
     /// Panics if the underlying C function returns a null pointer.
-    pub fn set_name<F>(&mut self, name: &str, callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+    pub fn set_name<F>(&mut self, name: &str, callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
         let c_name = CString::new(name.clone()).unwrap();
 
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_context_set_name(self.ptr, c_name.as_ptr(),
             Some(success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Gets the server name this context is connected to.
@@ -488,20 +488,20 @@ impl Context {
     ///
     /// Panics if the underlying C function returns a null pointer.
     pub fn proplist_update<F>(&mut self, mode: proplist::UpdateMode, pl: &Proplist, callback: F)
-        -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+        -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_context_proplist_update(self.ptr, mode, pl.0.ptr,
             Some(success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Updates the property list of the client, remove entries.
     ///
     /// Panics if the underlying C function returns a null pointer.
-    pub fn proplist_remove<F>(&mut self, keys: &[&str], callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+    pub fn proplist_remove<F>(&mut self, keys: &[&str], callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -518,10 +518,10 @@ impl Context {
         }
         c_key_ptrs.push(null());
 
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_context_proplist_remove(self.ptr, c_key_ptrs.as_ptr(),
             Some(success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Gets the client index this context is identified in the server with.
@@ -646,7 +646,7 @@ fn success_cb_proxy(_: *mut ContextInternal, success: i32, userdata: *mut c_void
     let _ = std::panic::catch_unwind(|| {
         assert!(!userdata.is_null());
         // Note, destroys closure callback after use - restoring outer box means it gets dropped
-        let mut callback = unsafe { Box::from_raw(userdata as *mut Box<dyn FnMut(bool)>) };
+        let callback = unsafe { Box::from_raw(userdata as *mut Box<dyn FnOnce(bool)>) };
         (callback)(success_actual);
     });
 }

--- a/pulse-binding/src/context/scache.rs
+++ b/pulse-binding/src/context/scache.rs
@@ -72,17 +72,17 @@ impl Context {
     /// The callback must accept a `bool`, which indicates success.
     ///
     /// Panics if the underlying C function returns a null pointer.
-    pub fn remove_sample<F>(&mut self, name: &str, callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+    pub fn remove_sample<F>(&mut self, name: &str, callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
         let c_name = CString::new(name.clone()).unwrap();
 
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_context_remove_sample(self.ptr, c_name.as_ptr(),
             Some(super::success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Plays a sample from the sample cache to the specified device.
@@ -100,7 +100,7 @@ impl Context {
     ///
     /// Panics if the underlying C function returns a null pointer.
     pub fn play_sample(&mut self, name: &str, dev: Option<&str>, volume: Option<Volume>,
-        callback: Option<Box<dyn FnMut(bool) + 'static>>) -> Operation<dyn FnMut(bool)>
+        callback: Option<Box<dyn FnOnce(bool) + 'static>>) -> Operation<dyn FnOnce(bool)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -118,7 +118,7 @@ impl Context {
         let ptr = unsafe {
             capi::pa_context_play_sample(self.ptr, c_name.as_ptr(), p_dev, vol.0, cb_fn, cb_data)
         };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Plays a sample from the sample cache to the specified device, allowing specification of a
@@ -142,8 +142,8 @@ impl Context {
     /// Panics if the underlying C function returns a null pointer.
     pub fn play_sample_with_proplist(&mut self, name: &str, dev: Option<&str>,
         volume: Option<Volume>, proplist: &Proplist,
-        callback: Option<Box<dyn FnMut(Result<u32, ()>) + 'static>>)
-        -> Operation<dyn FnMut(Result<u32, ()>)>
+        callback: Option<Box<dyn FnOnce(Result<u32, ()>) + 'static>>)
+        -> Operation<dyn FnOnce(Result<u32, ()>)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a
         // variable, leading to as_ptr() giving dangling pointers!
@@ -162,7 +162,7 @@ impl Context {
             capi::pa_context_play_sample_with_proplist(self.ptr, c_name.as_ptr(), p_dev, vol.0,
                 proplist.0.ptr, cb_fn, cb_data)
         };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(Result<u32, ()>)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(Result<u32, ()>)>)
     }
 }
 
@@ -174,7 +174,7 @@ fn play_sample_success_cb_proxy(_: *mut ContextInternal, index: u32, userdata: *
     let index_actual = match index { def::INVALID_INDEX => Err(()), i => Ok(i) };
     let _ = std::panic::catch_unwind(|| {
         // Note, destroys closure callback after use - restoring outer box means it gets dropped
-        let mut callback = get_su_callback::<dyn FnMut(Result<u32, ()>)>(userdata);
+        let callback = get_su_callback::<dyn FnOnce(Result<u32, ()>)>(userdata);
         (callback)(index_actual);
     });
 }

--- a/pulse-binding/src/context/subscribe.rs
+++ b/pulse-binding/src/context/subscribe.rs
@@ -219,13 +219,13 @@ impl Context {
     ///
     /// [`set_subscribe_callback()`]: Self::set_subscribe_callback
     pub fn subscribe<F>(&mut self, mask: InterestMaskSet, callback: F)
-        -> operation::Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+        -> operation::Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_context_subscribe(self.ptr, mask.bits(),
             Some(super::success_cb_proxy), cb_data) };
-        operation::Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        operation::Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the context specific call back function that is called whenever a subscribed-to event

--- a/pulse-binding/src/mainloop/api.rs
+++ b/pulse-binding/src/mainloop/api.rs
@@ -306,7 +306,7 @@ pub trait Mainloop {
     /// rules regarding how to safely create defer events. In particular, if you’re using
     /// [`mainloop::threaded`](mod@crate::mainloop::threaded), you must lock the mainloop before
     /// calling this function.
-    fn once_event(&mut self, callback: Box<dyn FnMut() + 'static>) {
+    fn once_event(&mut self, callback: Box<dyn FnOnce() + 'static>) {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _)>, _) =
             get_su_capi_params::<_, _>(Some(callback), once_cb_proxy);
 
@@ -426,7 +426,7 @@ extern "C"
 fn once_cb_proxy(_: *const ApiInternal, userdata: *mut c_void) {
     let _ = std::panic::catch_unwind(|| {
         // Note, destroys closure callback after use - restoring outer box means it gets dropped
-        let mut callback = get_su_callback::<dyn FnMut()>(userdata);
+        let callback = get_su_callback::<dyn FnOnce()>(userdata);
         (callback)();
     });
 }

--- a/pulse-binding/src/stream.rs
+++ b/pulse-binding/src/stream.rs
@@ -1253,13 +1253,13 @@ impl Stream {
     /// The optional callback must accept a `bool`, which indicates success.
     ///
     /// Panics if the underlying C function returns a null pointer.
-    pub fn drain(&mut self, callback: Option<Box<dyn FnMut(bool) + 'static>>)
-        -> Operation<dyn FnMut(bool)>
+    pub fn drain(&mut self, callback: Option<Box<dyn FnOnce(bool) + 'static>>)
+        -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, success_cb_proxy);
         let ptr = unsafe { capi::pa_stream_drain(self.ptr, cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Requests a timing info structure update for a stream.
@@ -1274,13 +1274,13 @@ impl Stream {
     /// [`get_timing_info()`]: Self::get_timing_info
     /// [`get_time()`]: Self::get_time
     /// [`get_latency()`]: Self::get_latency
-    pub fn update_timing_info(&mut self, callback: Option<Box<dyn FnMut(bool) + 'static>>)
-        -> Operation<dyn FnMut(bool)>
+    pub fn update_timing_info(&mut self, callback: Option<Box<dyn FnOnce(bool) + 'static>>)
+        -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, success_cb_proxy);
         let ptr = unsafe { capi::pa_stream_update_timing_info(self.ptr, cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Sets the callback function that is called whenever the state of the stream changes.
@@ -1441,13 +1441,13 @@ impl Stream {
     /// Panics if the underlying C function returns a null pointer.
     ///
     /// [`is_corked()`]: Self::is_corked
-    pub fn cork(&mut self, callback: Option<Box<dyn FnMut(bool) + 'static>>)
-        -> Operation<dyn FnMut(bool)>
+    pub fn cork(&mut self, callback: Option<Box<dyn FnOnce(bool) + 'static>>)
+        -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, success_cb_proxy);
         let ptr = unsafe { capi::pa_stream_cork(self.ptr, true as i32, cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Resumes playback of this stream.
@@ -1465,13 +1465,13 @@ impl Stream {
     /// Panics if the underlying C function returns a null pointer.
     ///
     /// [`is_corked()`]: Self::is_corked
-    pub fn uncork(&mut self, callback: Option<Box<dyn FnMut(bool) + 'static>>)
-        -> Operation<dyn FnMut(bool)>
+    pub fn uncork(&mut self, callback: Option<Box<dyn FnOnce(bool) + 'static>>)
+        -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, success_cb_proxy);
         let ptr = unsafe { capi::pa_stream_cork(self.ptr, false as i32, cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Flushes the playback or record buffer of this stream.
@@ -1482,13 +1482,13 @@ impl Stream {
     /// The optional callback must accept a `bool`, which indicates success.
     ///
     /// Panics if the underlying C function returns a null pointer.
-    pub fn flush(&mut self, callback: Option<Box<dyn FnMut(bool) + 'static>>)
-        -> Operation<dyn FnMut(bool)>
+    pub fn flush(&mut self, callback: Option<Box<dyn FnOnce(bool) + 'static>>)
+        -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, success_cb_proxy);
         let ptr = unsafe { capi::pa_stream_flush(self.ptr, cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Re-enables prebuffering if specified in the [`BufferAttr`] structure.
@@ -1500,13 +1500,13 @@ impl Stream {
     /// Panics if the underlying C function returns a null pointer.
     ///
     /// [`BufferAttr`]: crate::def::BufferAttr
-    pub fn prebuf(&mut self, callback: Option<Box<dyn FnMut(bool) + 'static>>)
-        -> Operation<dyn FnMut(bool)>
+    pub fn prebuf(&mut self, callback: Option<Box<dyn FnOnce(bool) + 'static>>)
+        -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, success_cb_proxy);
         let ptr = unsafe { capi::pa_stream_prebuf(self.ptr, cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Requests immediate start of playback on this stream.
@@ -1519,13 +1519,13 @@ impl Stream {
     /// Panics if the underlying C function returns a null pointer.
     ///
     /// [`BufferAttr`]: crate::def::BufferAttr
-    pub fn trigger(&mut self, callback: Option<Box<dyn FnMut(bool) + 'static>>)
-        -> Operation<dyn FnMut(bool)>
+    pub fn trigger(&mut self, callback: Option<Box<dyn FnOnce(bool) + 'static>>)
+        -> Operation<dyn FnOnce(bool)>
     {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, success_cb_proxy);
         let ptr = unsafe { capi::pa_stream_trigger(self.ptr, cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Renames the stream.
@@ -1533,8 +1533,8 @@ impl Stream {
     /// The optional callback must accept a `bool`, which indicates success.
     ///
     /// Panics if the underlying C function returns a null pointer.
-    pub fn set_name(&mut self, name: &str, callback: Option<Box<dyn FnMut(bool) + 'static>>)
-        -> Operation<dyn FnMut(bool)>
+    pub fn set_name(&mut self, name: &str, callback: Option<Box<dyn FnOnce(bool) + 'static>>)
+        -> Operation<dyn FnOnce(bool)>
     {
         // Warning: New CStrings will be immediately freed if not bound to a
         // variable, leading to as_ptr() giving dangling pointers!
@@ -1543,7 +1543,7 @@ impl Stream {
         let (cb_fn, cb_data): (Option<extern "C" fn(_, _, _)>, _) =
             get_su_capi_params::<_, _>(callback, success_cb_proxy);
         let ptr = unsafe { capi::pa_stream_set_name(self.ptr, c_name.as_ptr(), cb_fn, cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Gets the current playback/recording time.
@@ -1689,13 +1689,13 @@ impl Stream {
     ///
     /// [`get_buffer_attr()`]: Self::get_buffer_attr
     pub fn set_buffer_attr<F>(&mut self, attr: &def::BufferAttr, callback: F)
-        -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+        -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_stream_set_buffer_attr(self.ptr, attr.as_ref(),
             Some(success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Changes the stream sampling rate during playback.
@@ -1709,13 +1709,13 @@ impl Stream {
     /// Panics if the underlying C function returns a null pointer.
     ///
     /// [`connect_playback()`]: Self::connect_playback
-    pub fn update_sample_rate<F>(&mut self, rate: u32, callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+    pub fn update_sample_rate<F>(&mut self, rate: u32, callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_stream_update_sample_rate(self.ptr, rate,
             Some(success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Updates the property list of the sink input/source output of this stream, adding new
@@ -1731,13 +1731,13 @@ impl Stream {
     ///
     /// [`new_with_proplist()`]: Self::new_with_proplist
     pub fn update_proplist<F>(&mut self, mode: proplist::UpdateMode, proplist: &mut Proplist,
-        callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+        callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe { capi::pa_stream_proplist_update(self.ptr, mode, proplist.0.ptr,
             Some(success_cb_proxy), cb_data) };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// Updates the property list of the sink input/source output of this stream, removing entries.
@@ -1745,8 +1745,8 @@ impl Stream {
     /// The callback must accept a `bool`, which indicates success.
     ///
     /// Panics if the underlying C function returns a null pointer.
-    pub fn remove_proplist<F>(&mut self, keys: &[&str], callback: F) -> Operation<dyn FnMut(bool)>
-        where F: FnMut(bool) + 'static
+    pub fn remove_proplist<F>(&mut self, keys: &[&str], callback: F) -> Operation<dyn FnOnce(bool)>
+        where F: FnOnce(bool) + 'static
     {
         // Warning: New CStrings will be immediately freed if not bound to a variable, leading to
         // as_ptr() giving dangling pointers!
@@ -1763,12 +1763,12 @@ impl Stream {
         }
         c_key_ptrs.push(null());
 
-        let cb_data = box_closure_get_capi_ptr::<dyn FnMut(bool)>(Box::new(callback));
+        let cb_data = box_closure_get_capi_ptr::<dyn FnOnce(bool)>(Box::new(callback));
         let ptr = unsafe {
             capi::pa_stream_proplist_remove(self.ptr, c_key_ptrs.as_ptr(),
                 Some(success_cb_proxy), cb_data)
         };
-        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnMut(bool)>)
+        Operation::from_raw(ptr, cb_data as *mut Box<dyn FnOnce(bool)>)
     }
 
     /// For record streams connected to a monitor source: monitors only a very specific sink input
@@ -1812,7 +1812,7 @@ fn success_cb_proxy(_: *mut StreamInternal, success: i32, userdata: *mut c_void)
     let success_actual = match success { 0 => false, _ => true };
     let _ = std::panic::catch_unwind(|| {
         // Note, destroys closure callback after use - restoring outer box means it gets dropped
-        let mut callback = get_su_callback::<dyn FnMut(bool)>(userdata);
+        let callback = get_su_callback::<dyn FnOnce(bool)>(userdata);
         (callback)(success_actual);
     });
 }


### PR DESCRIPTION
This is more general than `FnMut`, which is useful in some cases.

https://github.com/jnqnfe/pulse-binding-rust/issues/50

It's hard to be sure that this covers everything (and the consistency of types can't be checked by the compiler everywhere due to pointer casts...), but this should be an improvement.